### PR TITLE
Add dashboard sheet charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This Google Apps Script manages EMRG leads in a Google Spreadsheet and syncs the
 - **📊 Show Dashboard** – view summary metrics in a sidebar.
 - **➕ Add New Lead** – open a form to create a lead and log it to the sheet.
 - **🔄 Re-sync All Rows** – update GoHighLevel with changes from the sheet.
+- **📈 Build Dashboard Sheet** – generate a `Dashboard` sheet with charts.
 - **🛠️ Initialize Leads Sheet** – rebuild the sheet structure.
 
 Editing a row marks it as `Pending` so it will be synchronized from the menu or by the optional 15‑minute trigger.


### PR DESCRIPTION
## Summary
- create a new `Dashboard` sheet with status and stage charts
- include a menu item for creating the dashboard
- document the new feature

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688374e06e488333875bf293f788295a