### PR TITLE
Add dashboard sheet charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This Google Apps Script manages EMRG leads in a Google Spreadsheet and syncs the
 - **📊 Show Dashboard** – view summary metrics in a sidebar.
 - **➕ Add New Lead** – open a form to create a lead and log it to the sheet.
 - **🔄 Re-sync All Rows** – update GoHighLevel with changes from the sheet.
+- **📈 Build Dashboard Sheet** – generate a `Dashboard` sheet with charts.
 - **🛠️ Initialize Leads Sheet** – rebuild the sheet structure.
 
 Editing a row marks it as `Pending` so it will be synchronized from the menu or by the optional 15‑minute trigger.

--- a/code.gs
+++ b/code.gs
@@ -94,6 +94,7 @@ function onOpen() {
     .addItem('📊 Show Dashboard', 'showSidebar')
     .addItem('➕ Add New Lead', 'showLeadForm')
     .addItem('🔄 Re-sync All Rows', 'resyncAllRows')
+    .addItem('📈 Build Dashboard Sheet', 'createDashboardSheet')
     .addItem('▶️ Enable Auto Sync', 'enableAutoSync')
     .addItem('⏹️ Disable Auto Sync', 'disableAutoSync')
     .addItem('🛠️ Initialize Leads Sheet', 'setupSheet')
@@ -377,4 +378,67 @@ function disableAutoSync() {
     }
   });
   PropertiesService.getScriptProperties().deleteProperty('AUTO_SYNC');
+}
+
+// ─── DASHBOARD SHEET ─────────────────────────────────────────────────────────
+function createDashboardSheet() {
+  const ss = SpreadsheetApp.getActive();
+  let sheet = ss.getSheetByName('Dashboard');
+  if (!sheet) {
+    sheet = ss.insertSheet('Dashboard');
+  } else {
+    sheet.clear();
+  }
+
+  const leads = ss.getSheetByName(SHEET_NAMES.leads);
+  if (!leads) {
+    SpreadsheetApp.getUi().alert('Leads sheet not found');
+    return;
+  }
+  const data = leads.getDataRange().getValues();
+  const headers = data.shift();
+  const idx = {
+    status: headers.indexOf('Status'),
+    stage: headers.indexOf('Stage'),
+    proposal: headers.indexOf('Proposal Amount'),
+  };
+
+  const statusCounts = {};
+  const stageCounts = {};
+  let totalProposal = 0;
+  data.forEach(r => {
+    const st = r[idx.status];
+    if (st) statusCounts[st] = (statusCounts[st] || 0) + 1;
+    const sg = r[idx.stage];
+    if (sg) stageCounts[sg] = (stageCounts[sg] || 0) + 1;
+    const amt = parseFloat(r[idx.proposal]);
+    if (!isNaN(amt)) totalProposal += amt;
+  });
+
+  sheet.getRange('A1').setValue('Total Proposal Amount');
+  sheet.getRange('B1').setValue(totalProposal);
+
+  const statusRows = Object.entries(statusCounts).map(([k, v]) => [k, v]);
+  const statusRange = sheet.getRange(3, 1, statusRows.length || 1, 2);
+  if (statusRows.length) statusRange.setValues(statusRows);
+  const pie = sheet
+    .newChart()
+    .setChartType(Charts.ChartType.PIE)
+    .addRange(statusRange)
+    .setPosition(3, 4, 0, 0)
+    .setOption('title', 'Status Distribution')
+    .build();
+  sheet.insertChart(pie);
+
+  const stageRows = Object.entries(stageCounts).map(([k, v]) => [k, v]);
+  const stageRange = sheet.getRange(3, 7, stageRows.length || 1, 2);
+  if (stageRows.length) stageRange.setValues(stageRows);
+  const colChart = sheet
+    .newChart()
+    .setChartType(Charts.ChartType.COLUMN)
+    .addRange(stageRange)
+    .setPosition(3, 10, 0, 0)
+    .setOption('title', 'Stage Counts')
+    .build();
+  sheet.insertChart(colChart);
 }


### PR DESCRIPTION
## Summary
- create a new `Dashboard` sheet with status and stage charts
- include a menu item for creating the dashboard
- document the new feature
- fix chart builder type error by using `setChartType`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688374e06e488333875bf293f788295a