### PR TITLE
docs: clarify lack of npm tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+# Pull Request
+
+Provide a summary of your changes. This Apps Script project has no Node dependencies or automated tests.
+
+- [ ] I have tested my changes manually in Apps Script.
+- [ ] I updated documentation if needed.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ This Google Apps Script manages EMRG leads in a Google Spreadsheet and syncs the
 - **🛠️ Initialize Leads Sheet** – rebuild the sheet structure.
 
 Editing a row marks it as `Pending` so it will be synchronized from the menu or by the optional 15‑minute trigger.
+
+## Development
+
+This project is built in Google Apps Script and does not use Node.js or `npm` packages. There are no automated tests, so you do not need to run `npm test`.


### PR DESCRIPTION
## Summary
- clarify that no Node.js or `npm test` is required
- add a basic pull request template

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883800d57408333b1b9b5686a351c5c