### PR TITLE
Add .gitignore for Apps Script project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore clasp project settings
+.clasp.json
+
+# Node dependencies
+node_modules/
+
+# Log files
+*.log
+
+# System files
+.DS_Store


### PR DESCRIPTION
## Summary
- create a `.gitignore` tailored for Apps Script development

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883800c35ec8333a064bb0fd03be428