### PR TITLE
Fix opportunity payload structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This Google Apps Script manages EMRG leads in a Google Spreadsheet and syncs the
 
 - **📊 Show Dashboard** – view summary metrics in a sidebar.
 - **➕ Add New Lead** – open a form to create a lead and log it to the sheet.
+- The script now sends contact details inside a `contact` object when creating a
+  new opportunity to comply with recent LeadConnector API updates.
 - **🔄 Re-sync All Rows** – update GoHighLevel with changes from the sheet.
 - **📈 Build Dashboard Sheet** – generate a `Dashboard` sheet with charts.
 - **🛠️ Initialize Leads Sheet** – rebuild the sheet structure.

--- a/code.gs
+++ b/code.gs
@@ -258,10 +258,12 @@ function createGhlOpportunityAndLogToSheet(formData) {
     pipelineId: CONFIG.PIPELINE_ID,
     pipelineStageId: CONFIG.INITIAL_STAGE_ID,
     status: formData.initialOpportunityStatus || 'open',
-    firstName: formData.firstName,
-    lastName: formData.lastName,
-    email: formData.email,
-    phone: formData.phone,
+    contact: {
+      firstName: formData.firstName,
+      lastName: formData.lastName,
+      email: formData.email,
+      phone: formData.phone,
+    }
   };
   if (formData.proposalAmount) payload.monetaryValue = Number(formData.proposalAmount);
 


### PR DESCRIPTION
## Summary
- nest contact info within a `contact` object when creating an opportunity
- document API change in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c7265df988333b30bcc816c3574b3